### PR TITLE
Fix #3: Implement correct extraction of icon groups algorithm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,7 +186,7 @@ cython_debug/
 #  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
 #  and can be added to the global gitignore or merged into this file. However, if you prefer, 
 #  you could uncomment the following to ignore the entire vscode folder
-# .vscode/
+.vscode/
 
 # Ruff stuff:
 .ruff_cache/

--- a/README.md
+++ b/README.md
@@ -52,16 +52,4 @@ The application automatically creates icons in these standard macOS sizes:
 
 The application handles errors gracefully and provides status updates throughout the process.
 
-## GitHub Repository Context
-
-- **Repository**: https://github.com/anakham/Exe2Iconset
-- **Open issues** (7 as of March 2026):
-  - #9 Make application bundle
-  - #8 Allow using all image files as icons.
-  - #7 Drag and drop support
-  - #6 Tune .gitignore
-  - #5 Inspect which platforms can be used to run application
-  - #4 Improve UI design
-  - #3 Implement correct extraction of icon groups algorithm
-
 For the latest issue list and details, see: https://github.com/anakham/Exe2Iconset/issues

--- a/README.md
+++ b/README.md
@@ -51,3 +51,17 @@ The application automatically creates icons in these standard macOS sizes:
 - Both regular and @2x (retina) versions where possible
 
 The application handles errors gracefully and provides status updates throughout the process.
+
+## GitHub Repository Context
+
+- **Repository**: https://github.com/anakham/Exe2Iconset
+- **Open issues** (7 as of March 2026):
+  - #9 Make application bundle
+  - #8 Allow using all image files as icons.
+  - #7 Drag and drop support
+  - #6 Tune .gitignore
+  - #5 Inspect which platforms can be used to run application
+  - #4 Improve UI design
+  - #3 Implement correct extraction of icon groups algorithm
+
+For the latest issue list and details, see: https://github.com/anakham/Exe2Iconset/issues

--- a/exe2iconset.py
+++ b/exe2iconset.py
@@ -5,7 +5,7 @@ import sys
 import tempfile
 import tkinter as tk
 from tkinter import ttk, filedialog, messagebox
-from PIL import Image, ImageTk
+from PIL import Image, ImageTk, ImageOps
 import shutil
 from pathlib import Path
 import json
@@ -287,6 +287,7 @@ class IconExtractorApp:
                 ba[i], ba[i+2] = ba[i+2], ba[i]
             
             img = Image.frombytes('RGBA', (biWidth, actual_height), bytes(ba), 'raw')
+            img = ImageOps.flip(img)
             buf = BytesIO()
             img.save(buf, 'PNG')
             return buf.getvalue()

--- a/exe2iconset.py
+++ b/exe2iconset.py
@@ -196,35 +196,6 @@ class IconExtractorApp:
             self.log_status(f"Error during extraction: {str(e)}")
             return
 
-    def _traverse_resource_directory(self, pe, entry, depth=0, results=None):
-        """Recursively traverse resource directory entries."""
-        if results is None:
-            results = []
-        
-        indent = "  " * depth
-        self.log_status(f"Debug: {indent}Level {depth}, entries: {len(entry.directory.entries)}")
-        
-        for idx, sub_entry in enumerate(entry.directory.entries):
-            entry_id = sub_entry.id if sub_entry.id else 0
-            entry_name = sub_entry.name if sub_entry.name else None
-            
-            self.log_status(f"Debug: {indent}  [{idx}] id={entry_id}, name={entry_name}")
-            
-            if hasattr(sub_entry, 'directory') and sub_entry.directory:
-                self._traverse_resource_directory(pe, sub_entry, depth + 1, results)
-            elif hasattr(sub_entry, 'data') and sub_entry.data:
-                rva = sub_entry.data.struct.OffsetToData
-                size = sub_entry.data.struct.Size
-                results.append({
-                    'id': entry_id,
-                    'name': entry_name,
-                    'rva': rva,
-                    'size': size,
-                    'depth': depth
-                })
-        
-        return results
-
     def _extract_resources_by_type(self, pe, resource_type_id):
         """Extract all resources of a specific type with proper recursion."""
         results = []
@@ -232,9 +203,11 @@ class IconExtractorApp:
         if not hasattr(pe, 'DIRECTORY_ENTRY_RESOURCE'):
             return results
         
+        resource_type_name = pefile.RESOURCE_TYPE.get(resource_type_id, f"UNKNOWN_{resource_type_id}")
+        
         for entry in pe.DIRECTORY_ENTRY_RESOURCE.entries:
             if entry.id == resource_type_id:
-                self.log_status(f"Debug: Found RT_{'ICON' if resource_type_id == 3 else 'GROUP_ICON'} (ID={resource_type_id})")
+                self.log_status(f"Debug: Found {resource_type_name} (ID={resource_type_id})")
                 
                 if hasattr(entry, 'directory') and entry.directory:
                     for sub_entry in entry.directory.entries:
@@ -248,13 +221,13 @@ class IconExtractorApp:
                                 lang_id = lang_entry.id if lang_entry.id else 0
                                 
                                 if hasattr(lang_entry, 'data') and lang_entry.data:
-                                    rva = lang_entry.data.struct.OffsetToData
+                                    offset = lang_entry.data.struct.OffsetToData
                                     size = lang_entry.data.struct.Size
                                     results.append({
                                         'id': sub_id,
                                         'name': sub_name,
                                         'lang': lang_id,
-                                        'rva': rva,
+                                        'offset': offset,
                                         'size': size
                                     })
         
@@ -296,6 +269,28 @@ class IconExtractorApp:
         struct.pack_into('<i', fixed_data, 8, biHeight // 2)
         return bytes(fixed_data)
 
+    def _read_icon_image(self, pe, offset, size):
+        """Read icon image from PE file and return RGBA PIL Image.
+        
+        Args:
+            pe: pefile.PE object
+            offset: offset to icon data in memory-mapped image
+            size: size of icon data
+            
+        Returns:
+            PIL Image in RGBA format, or None if extraction fails
+        """
+        raw_data = pe.get_memory_mapped_image()[offset:offset+size]
+        fixed_data = self._fix_dib_data(raw_data)
+        
+        try:
+            img = Image.open(BytesIO(fixed_data))
+            if img.mode != 'RGBA':
+                img = img.convert('RGBA')
+            return img
+        except Exception:
+            return None
+
     def extract_icons_from_pe(self, file_path):
         """Extract icon groups from PE resources using pefile."""
         try:
@@ -322,17 +317,19 @@ class IconExtractorApp:
             self.log_status(f"Debug: Found {len(rt_icon_resources)} RT_ICON entries")
             
             for res in rt_icon_resources:
-                data = pe.get_memory_mapped_image()[res['rva']:res['rva']+res['size']]
-                icon_by_id[res['id']] = data
+                icon_by_id[(res['id'], res['lang'])] = {
+                    'offset': res['offset'],
+                    'size': res['size']
+                }
 
             rt_group_resources = self._extract_resources_by_type(pe, pefile.RESOURCE_TYPE['RT_GROUP_ICON'])
             self.log_status(f"Debug: Found {len(rt_group_resources)} RT_GROUP_ICON entries")
             
-            group_icon_entries = [(res['id'], res['rva'], res['size']) for res in rt_group_resources]
+            group_icon_entries = [(res['id'], res['lang'], res['offset'], res['size']) for res in rt_group_resources]
 
             # Parse each group icon after all ICON resources are collected
-            for group_id, data_rva, size in group_icon_entries:
-                data = pe.get_memory_mapped_image()[data_rva:data_rva+size]
+            for group_id, group_lang, data_offset, size in group_icon_entries:
+                data = pe.get_memory_mapped_image()[data_offset:data_offset+size]
                 if len(data) < 6:
                     continue
 
@@ -357,21 +354,23 @@ class IconExtractorApp:
                     })
                     offset += 14
 
-                group_key = f"icongroup_{group_id}"
+                group_key = f"icongroup_{group_id}_{group_lang}"
                 icon_list = []
 
                 for e in entries:
                     rid = e['id']
-                    icon_data = icon_by_id.get(rid)
+                    icon_data = icon_by_id.get((rid, group_lang))
                     if not icon_data:
                         continue
                     width = e['width'] if e['width'] != 0 else 256
                     height = e['height'] if e['height'] != 0 else 256
-                    icon_list.append({
-                        'width': width,
-                        'height': height,
-                        'data': icon_data
-                    })
+                    img = self._read_icon_image(pe, icon_data.get('offset', 0), icon_data.get('size', 0))
+                    if img:
+                        icon_list.append({
+                            'width': width,
+                            'height': height,
+                            'image': img
+                        })
 
                 if icon_list:
                     groups[group_key] = icon_list
@@ -399,9 +398,7 @@ class IconExtractorApp:
             if icon_data_list:
                 try:
                     first_icon = icon_data_list[0]
-                    img_data = self._fix_dib_data(first_icon['data'])
-                    img = Image.open(BytesIO(img_data))
-                    img = img.resize((64, 64), Image.Resampling.LANCZOS)
+                    img = first_icon['image'].resize((64, 64), Image.Resampling.LANCZOS)
                     
                     photo = ImageTk.PhotoImage(img)
                     
@@ -477,8 +474,8 @@ class IconExtractorApp:
             icon_sizes = []
             for icon_entry in icon_data_list:
                 try:
-                    img = Image.open(BytesIO(icon_entry['data']))
-                    icon_sizes.append((icon_entry['width'], icon_entry['height'], icon_entry['data']))
+                    img = icon_entry['image'].copy()
+                    icon_sizes.append((icon_entry['width'], icon_entry['height'], img))
                 except Exception as e:
                     self.log_status(f"Warning: Could not read icon data: {str(e)}")
                     continue
@@ -499,15 +496,11 @@ class IconExtractorApp:
                         best_source = (src_w, src_h, src_data)
                 
                 if best_source:
-                    src_w, src_h, src_data = best_source
+                    src_w, src_h, src_img = best_source
+                    src_img = src_img.copy()
                     
                     try:
-                        img_data = self._fix_dib_data(src_data)
-                        img = Image.open(BytesIO(img_data))
-                        if img.mode != 'RGBA':
-                            img = img.convert('RGBA')
-                        
-                        resized = img.resize((target_w, target_h), Image.Resampling.LANCZOS)
+                        resized = src_img.resize((target_w, target_h), Image.Resampling.LANCZOS)
                         
                         regular_name = f"icon_{target_w}x{target_h}.png"
                         regular_path = os.path.join(iconset_path, regular_name)
@@ -518,7 +511,7 @@ class IconExtractorApp:
                         retina_path = os.path.join(iconset_path, retina_name)
                         
                         if src_w >= target_w and src_h >= target_h:
-                            retina_img = img.resize((target_w, target_h), Image.Resampling.LANCZOS)
+                            retina_img = resized
                             retina_img.save(retina_path, 'PNG')
                             created_files.append(retina_path)
                     

--- a/exe2iconset.py
+++ b/exe2iconset.py
@@ -1,4 +1,5 @@
 import os
+import struct
 import subprocess
 import sys
 import tempfile
@@ -9,6 +10,12 @@ import shutil
 from pathlib import Path
 import json
 import threading
+from io import BytesIO
+
+try:
+    import pefile
+except ImportError:
+    pefile = None
 
 class IconExtractorApp:
     def __init__(self, root):
@@ -21,10 +28,8 @@ class IconExtractorApp:
         
         # Variables
         self.exe_path = tk.StringVar()
-        self.extracted_path = tk.StringVar()
         self.selected_icons = []
         self.icon_series = {}
-        self.temp_dir = None
         self.selected_series_key = None
         
         # Create UI
@@ -121,12 +126,10 @@ class IconExtractorApp:
         """Check if required tools are available"""
         missing_tools = []
         
-        # Check for 7z
-        try:
-            subprocess.run(['7z', '--help'], capture_output=True)
-        except FileNotFoundError:
-            missing_tools.append("7-Zip (7z.exe)")
-        
+        # Check for pefile library (required for internal PE resource parsing)
+        if pefile is None:
+            missing_tools.append("pefile (Python package)")
+
         # Check for iconutil (macOS) - we'll use alternative if not available
         self.iconutil_available = False
         if sys.platform == 'darwin':
@@ -167,14 +170,6 @@ class IconExtractorApp:
         self.selected_icons = []
         self.icon_series = {}
         
-        # Create temp directory
-        if self.temp_dir and os.path.exists(self.temp_dir):
-            shutil.rmtree(self.temp_dir)
-        
-        self.temp_dir = tempfile.mkdtemp()
-        self.extracted_path.set(self.temp_dir)
-        
-        # Run extraction in thread to avoid UI freeze
         thread = threading.Thread(target=self._extract_icons_thread)
         thread.daemon = True
         thread.start()
@@ -183,98 +178,212 @@ class IconExtractorApp:
         self.log_status("Extracting resources from EXE file...")
         
         try:
-            # Use 7z to extract resources
-            cmd = ['7z', 'x', self.exe_path.get(), '-o' + self.temp_dir, '-y']
-            
-            # Run 7z extraction
-            result = subprocess.run(cmd, capture_output=True, text=True)
-            
-            if result.returncode != 0:
-                self.log_status(f"Extraction failed: {result.stderr}")
-                return
-            
-            self.log_status("Extraction completed. Scanning for icons...")
-            
-            # Find icon files
-            icon_files = []
-            for root, dirs, files in os.walk(self.temp_dir):
-                for file in files:
-                    if file.lower().endswith('.ico') or '.icon' in file.lower():
-                        icon_files.append(os.path.join(root, file))
-            
+            self.log_status("Extracting icons from PE resources...")
+
+            icon_files = self.extract_icons_from_pe(self.exe_path.get())
             if not icon_files:
-                # Look for any image files that might be icons
-                for root, dirs, files in os.walk(self.temp_dir):
-                    for file in files:
-                        if any(file.lower().endswith(ext) for ext in ['.png', '.bmp', '.jpg', '.jpeg']):
-                            icon_files.append(os.path.join(root, file))
-            
-            if not icon_files:
-                self.log_status("No icons found in the extracted resources.")
+                self.log_status("No icons found in the PE resources.")
                 return
-            
-            self.log_status(f"Found {len(icon_files)} potential icon files.")
-            
-            # Group icons by series (by base name)
-            for icon_file in icon_files:
-                basename = os.path.basename(icon_file)
-                # Extract series name (remove numbers and extensions)
-                import re
-                series_name = re.sub(r'\d+', '', basename)
-                series_name = re.sub(r'[._-].*$', '', series_name)
-                series_name = series_name.lower()
-                
-                if series_name not in self.icon_series:
-                    self.icon_series[series_name] = []
-                
-                self.icon_series[series_name].append(icon_file)
-            
+
+            self.icon_series = icon_files
+            self.log_status(f"Extracted {len(self.icon_series)} icon groups from PE resources.")
+
             # Display icons in UI (must be done in main thread)
             self.root.after(0, self.display_icons)
-            
+            return
+
         except Exception as e:
             self.log_status(f"Error during extraction: {str(e)}")
-    
+            return
+
+    def _traverse_resource_directory(self, pe, entry, depth=0, results=None):
+        """Recursively traverse resource directory entries."""
+        if results is None:
+            results = []
+        
+        indent = "  " * depth
+        self.log_status(f"Debug: {indent}Level {depth}, entries: {len(entry.directory.entries)}")
+        
+        for idx, sub_entry in enumerate(entry.directory.entries):
+            entry_id = sub_entry.id if sub_entry.id else 0
+            entry_name = sub_entry.name if sub_entry.name else None
+            
+            self.log_status(f"Debug: {indent}  [{idx}] id={entry_id}, name={entry_name}")
+            
+            if hasattr(sub_entry, 'directory') and sub_entry.directory:
+                self._traverse_resource_directory(pe, sub_entry, depth + 1, results)
+            elif hasattr(sub_entry, 'data') and sub_entry.data:
+                rva = sub_entry.data.struct.OffsetToData
+                size = sub_entry.data.struct.Size
+                results.append({
+                    'id': entry_id,
+                    'name': entry_name,
+                    'rva': rva,
+                    'size': size,
+                    'depth': depth
+                })
+        
+        return results
+
+    def _extract_resources_by_type(self, pe, resource_type_id):
+        """Extract all resources of a specific type with proper recursion."""
+        results = []
+        
+        if not hasattr(pe, 'DIRECTORY_ENTRY_RESOURCE'):
+            return results
+        
+        for entry in pe.DIRECTORY_ENTRY_RESOURCE.entries:
+            if entry.id == resource_type_id:
+                self.log_status(f"Debug: Found RT_{'ICON' if resource_type_id == 3 else 'GROUP_ICON'} (ID={resource_type_id})")
+                
+                if hasattr(entry, 'directory') and entry.directory:
+                    for sub_entry in entry.directory.entries:
+                        sub_id = sub_entry.id if sub_entry.id else 0
+                        sub_name = sub_entry.name if sub_entry.name else None
+                        
+                        self.log_status(f"Debug:   Resource ID={sub_id}, name={sub_name}")
+                        
+                        if hasattr(sub_entry, 'directory') and sub_entry.directory:
+                            for lang_entry in sub_entry.directory.entries:
+                                lang_id = lang_entry.id if lang_entry.id else 0
+                                
+                                if hasattr(lang_entry, 'data') and lang_entry.data:
+                                    rva = lang_entry.data.struct.OffsetToData
+                                    size = lang_entry.data.struct.Size
+                                    results.append({
+                                        'id': sub_id,
+                                        'name': sub_name,
+                                        'lang': lang_id,
+                                        'rva': rva,
+                                        'size': size
+                                    })
+        
+        return results
+
+    def extract_icons_from_pe(self, file_path):
+        """Extract icon groups from PE resources using pefile."""
+        try:
+            if pefile is None:
+                self.log_status("pefile library not available")
+                return {}
+
+            pe = pefile.PE(file_path)
+
+            if not hasattr(pe, 'DIRECTORY_ENTRY_RESOURCE'):
+                self.log_status("No resource directory found in PE file")
+                return {}
+
+            self.log_status("Debug: Starting resource directory traversal...")
+            self.log_status(f"Debug: Root resource entries: {len(pe.DIRECTORY_ENTRY_RESOURCE.entries)}")
+            
+            for entry in pe.DIRECTORY_ENTRY_RESOURCE.entries:
+                self.log_status(f"Debug: Root entry id={entry.id}, name={entry.name}")
+
+            icon_by_id = {}
+            groups = {}
+
+            rt_icon_resources = self._extract_resources_by_type(pe, pefile.RESOURCE_TYPE['RT_ICON'])
+            self.log_status(f"Debug: Found {len(rt_icon_resources)} RT_ICON entries")
+            
+            for res in rt_icon_resources:
+                data = pe.get_memory_mapped_image()[res['rva']:res['rva']+res['size']]
+                icon_by_id[res['id']] = data
+
+            rt_group_resources = self._extract_resources_by_type(pe, pefile.RESOURCE_TYPE['RT_GROUP_ICON'])
+            self.log_status(f"Debug: Found {len(rt_group_resources)} RT_GROUP_ICON entries")
+            
+            group_icon_entries = [(res['id'], res['rva'], res['size']) for res in rt_group_resources]
+
+            # Parse each group icon after all ICON resources are collected
+            for group_id, data_rva, size in group_icon_entries:
+                data = pe.get_memory_mapped_image()[data_rva:data_rva+size]
+                if len(data) < 6:
+                    continue
+
+                idReserved, idType, idCount = struct.unpack('<HHH', data[:6])
+                if idReserved != 0 or idType != 1:
+                    continue
+
+                entries = []
+                offset = 6
+                for _ in range(idCount):
+                    if offset + 14 > len(data):
+                        break
+                    bWidth, bHeight, bColorCount, bReserved, wPlanes, wBitCount, dwBytesInRes, nID = struct.unpack('<BBBBHHIH', data[offset:offset+14])
+                    entries.append({
+                        'width': bWidth,
+                        'height': bHeight,
+                        'color_count': bColorCount,
+                        'planes': wPlanes,
+                        'bit_count': wBitCount,
+                        'bytes_in_res': dwBytesInRes,
+                        'id': nID,
+                    })
+                    offset += 14
+
+                group_key = f"icongroup_{group_id}"
+                ico_header = struct.pack('<HHH', 0, 1, len(entries))
+                dir_entries = b''
+                image_data = b''
+                image_offset = 6 + 16 * len(entries)
+
+                for e in entries:
+                    rid = e['id']
+                    icon_data = icon_by_id.get(rid)
+                    if not icon_data:
+                        continue
+                    size2 = len(icon_data)
+                    width = e['width'] if e['width'] != 0 else 256
+                    height = e['height'] if e['height'] != 0 else 256
+                    dir_entries += struct.pack('<BBBBHHII', width if width<=255 else 0, height if height<=255 else 0, e['color_count'], 0, e['planes'], e['bit_count'], size2, image_offset)
+                    image_data += icon_data
+                    image_offset += size2
+
+                if dir_entries:
+                    ico_bytes = ico_header + dir_entries + image_data
+                    if group_key not in groups:
+                        groups[group_key] = []
+                    groups[group_key].append(ico_bytes)
+                else:
+                    self.log_status(f"Warning: Icon group {group_id} has no valid icons")
+
+            for group_key in groups:
+                self.log_status(f"Debug: Group {group_key}: {len(groups[group_key])} icon(s)")
+
+            return groups
+
+        except Exception as e:
+            self.log_status(f"PE icon extraction failed: {str(e)}")
+            return {}
+
     def display_icons(self):
         """Display extracted icons in the UI"""
         row, col = 0, 0
         max_cols = 5
         
-        for series_name, icon_files in self.icon_series.items():
-            # Create a frame for this series
+        for series_name, icon_data_list in self.icon_series.items():
             series_frame = ttk.LabelFrame(self.icon_container, text=series_name, padding="5")
             series_frame.grid(row=row, column=col, padx=5, pady=5, sticky=(tk.W, tk.E, tk.N, tk.S))
             
-            # Display first icon in series as preview
-            if icon_files:
+            if icon_data_list:
                 try:
-                    # Try to open as ICO or image
-                    if icon_files[0].lower().endswith('.ico'):
-                        # For ICO files, extract first image
-                        from PIL import Image
-                        img = Image.open(icon_files[0])
-                        # Get the largest icon from the ICO
-                        img_size = img.size
-                        img = img.resize((64, 64), Image.Resampling.LANCZOS)
-                    else:
-                        img = Image.open(icon_files[0])
-                        img.thumbnail((64, 64), Image.Resampling.LANCZOS)
+                    img_data = icon_data_list[0]
+                    img = Image.open(BytesIO(img_data))
+                    img = img.resize((64, 64), Image.Resampling.LANCZOS)
                     
                     photo = ImageTk.PhotoImage(img)
                     
                     icon_label = ttk.Label(series_frame, image=photo)
-                    icon_label.image = photo  # Keep reference
+                    icon_label.image = photo
                     icon_label.grid(row=0, column=0, padx=5, pady=5)
                     
                 except Exception as e:
-                    error_label = ttk.Label(series_frame, text="Error loading")
+                    error_label = ttk.Label(series_frame, text=f"Error: {str(e)[:20]}")
                     error_label.grid(row=0, column=0, padx=5, pady=5)
             
-            # Series info
-            info_label = ttk.Label(series_frame, text=f"{len(icon_files)} icons")
+            info_label = ttk.Label(series_frame, text=f"{len(icon_data_list)} icons")
             info_label.grid(row=1, column=0, padx=5, pady=(0, 5))
             
-            # Select button
             select_btn = ttk.Button(series_frame, text="Select Series", 
                                     command=lambda sn=series_name: self.select_series(sn))
             select_btn.grid(row=2, column=0, padx=5, pady=(0, 5))
@@ -318,9 +427,8 @@ class IconExtractorApp:
         self.log_status("Starting ICNS conversion...")
         
         try:
-            icon_files = self.icon_series[self.selected_series_key]
+            icon_data_list = self.icon_series[self.selected_series_key]
             
-            # Create iconset directory
             iconset_name = self.output_name.get() + ".iconset"
             iconset_path = os.path.join(output_dir, iconset_name)
             
@@ -329,70 +437,60 @@ class IconExtractorApp:
             
             os.makedirs(iconset_path)
             
-            # macOS icon sizes (in pixels)
             mac_icon_sizes = [
                 (16, 16), (32, 32), (64, 64), (128, 128),
                 (256, 256), (512, 512), (1024, 1024)
             ]
             
-            # Sort icon files by size (largest first)
             icon_sizes = []
-            for icon_file in icon_files:
+            for icon_data in icon_data_list:
                 try:
-                    with Image.open(icon_file) as img:
-                        icon_sizes.append((img.width, img.height, icon_file))
-                except:
+                    img = Image.open(BytesIO(icon_data))
+                    icon_sizes.append((img.width, img.height, icon_data))
+                except Exception as e:
+                    self.log_status(f"Warning: Could not read icon data: {str(e)}")
                     continue
             
-            # Sort by total pixels (width * height)
             icon_sizes.sort(key=lambda x: x[0] * x[1], reverse=True)
             
             self.log_status(f"Processing {len(icon_sizes)} icons...")
             
-            # Create resized versions for each macOS size
             created_files = []
             for target_w, target_h in mac_icon_sizes:
-                # Find the closest source icon
                 best_source = None
                 best_diff = float('inf')
                 
-                for src_w, src_h, src_file in icon_sizes:
+                for src_w, src_h, src_data in icon_sizes:
                     diff = abs(src_w - target_w) + abs(src_h - target_h)
                     if diff < best_diff:
                         best_diff = diff
-                        best_source = (src_w, src_h, src_file)
+                        best_source = (src_w, src_h, src_data)
                 
                 if best_source:
-                    src_w, src_h, src_file = best_source
+                    src_w, src_h, src_data = best_source
                     
                     try:
-                        with Image.open(src_file) as img:
-                            # Resize to target size
-                            if img.mode != 'RGBA':
-                                img = img.convert('RGBA')
-                            
-                            # Create resized image
-                            resized = img.resize((target_w, target_h), Image.Resampling.LANCZOS)
-                            
-                            # Save in iconset with proper naming
-                            # Regular size
-                            regular_name = f"icon_{target_w}x{target_h}.png"
-                            regular_path = os.path.join(iconset_path, regular_name)
-                            resized.save(regular_path, 'PNG')
-                            created_files.append(regular_path)
-                            
-                            # Retina size (2x)
-                            retina_name = f"icon_{target_w//2}x{target_h//2}@2x.png"
-                            retina_path = os.path.join(iconset_path, retina_name)
-                            
-                            # Create retina version if source is large enough
-                            if src_w >= target_w and src_h >= target_h:
-                                retina_img = img.resize((target_w, target_h), Image.Resampling.LANCZOS)
-                                retina_img.save(retina_path, 'PNG')
-                                created_files.append(retina_path)
+                        img = Image.open(BytesIO(src_data))
+                        if img.mode != 'RGBA':
+                            img = img.convert('RGBA')
+                        
+                        resized = img.resize((target_w, target_h), Image.Resampling.LANCZOS)
+                        
+                        regular_name = f"icon_{target_w}x{target_h}.png"
+                        regular_path = os.path.join(iconset_path, regular_name)
+                        resized.save(regular_path, 'PNG')
+                        created_files.append(regular_path)
+                        
+                        retina_name = f"icon_{target_w//2}x{target_h//2}@2x.png"
+                        retina_path = os.path.join(iconset_path, retina_name)
+                        
+                        if src_w >= target_w and src_h >= target_h:
+                            retina_img = img.resize((target_w, target_h), Image.Resampling.LANCZOS)
+                            retina_img.save(retina_path, 'PNG')
+                            created_files.append(retina_path)
                     
                     except Exception as e:
-                        self.log_status(f"Error processing {src_file}: {str(e)}")
+                        self.log_status(f"Error processing icon: {str(e)}")
             
             self.log_status(f"Created {len(created_files)} PNG files in iconset.")
             
@@ -460,14 +558,7 @@ def main():
     root = tk.Tk()
     app = IconExtractorApp(root)
     
-    # Handle window closing
     def on_closing():
-        # Clean up temp directory
-        if app.temp_dir and os.path.exists(app.temp_dir):
-            try:
-                shutil.rmtree(app.temp_dir)
-            except:
-                pass
         root.destroy()
     
     root.protocol("WM_DELETE_WINDOW", on_closing)

--- a/exe2iconset.py
+++ b/exe2iconset.py
@@ -277,6 +277,20 @@ class IconExtractorApp:
         if biWidth <= 0:
             return data
         
+        biBitCount = int.from_bytes(data[14:16], 'little')
+        
+        if biBitCount == 32:
+            actual_height = biHeight // 2
+            pixel_data = data[40:40 + biWidth * actual_height * 4]
+            ba = bytearray(pixel_data)
+            for i in range(0, len(ba), 4):
+                ba[i], ba[i+2] = ba[i+2], ba[i]
+            
+            img = Image.frombytes('RGBA', (biWidth, actual_height), bytes(ba), 'raw')
+            buf = BytesIO()
+            img.save(buf, 'PNG')
+            return buf.getvalue()
+        
         fixed_data = bytearray(data)
         struct.pack_into('<i', fixed_data, 8, biHeight // 2)
         return bytes(fixed_data)

--- a/exe2iconset.py
+++ b/exe2iconset.py
@@ -322,33 +322,28 @@ class IconExtractorApp:
                     offset += 14
 
                 group_key = f"icongroup_{group_id}"
-                ico_header = struct.pack('<HHH', 0, 1, len(entries))
-                dir_entries = b''
-                image_data = b''
-                image_offset = 6 + 16 * len(entries)
+                icon_list = []
 
                 for e in entries:
                     rid = e['id']
                     icon_data = icon_by_id.get(rid)
                     if not icon_data:
                         continue
-                    size2 = len(icon_data)
                     width = e['width'] if e['width'] != 0 else 256
                     height = e['height'] if e['height'] != 0 else 256
-                    dir_entries += struct.pack('<BBBBHHII', width if width<=255 else 0, height if height<=255 else 0, e['color_count'], 0, e['planes'], e['bit_count'], size2, image_offset)
-                    image_data += icon_data
-                    image_offset += size2
+                    icon_list.append({
+                        'width': width,
+                        'height': height,
+                        'data': icon_data
+                    })
 
-                if dir_entries:
-                    ico_bytes = ico_header + dir_entries + image_data
-                    if group_key not in groups:
-                        groups[group_key] = []
-                    groups[group_key].append(ico_bytes)
+                if icon_list:
+                    groups[group_key] = icon_list
                 else:
                     self.log_status(f"Warning: Icon group {group_id} has no valid icons")
 
-            for group_key in groups:
-                self.log_status(f"Debug: Group {group_key}: {len(groups[group_key])} icon(s)")
+            for group_key, icon_list in groups.items():
+                self.log_status(f"Debug: Group {group_key}: {len(icon_list)} icon(s)")
 
             return groups
 
@@ -367,8 +362,8 @@ class IconExtractorApp:
             
             if icon_data_list:
                 try:
-                    img_data = icon_data_list[0]
-                    img = Image.open(BytesIO(img_data))
+                    first_icon = icon_data_list[0]
+                    img = Image.open(BytesIO(first_icon['data']))
                     img = img.resize((64, 64), Image.Resampling.LANCZOS)
                     
                     photo = ImageTk.PhotoImage(img)
@@ -443,10 +438,10 @@ class IconExtractorApp:
             ]
             
             icon_sizes = []
-            for icon_data in icon_data_list:
+            for icon_entry in icon_data_list:
                 try:
-                    img = Image.open(BytesIO(icon_data))
-                    icon_sizes.append((img.width, img.height, icon_data))
+                    img = Image.open(BytesIO(icon_entry['data']))
+                    icon_sizes.append((icon_entry['width'], icon_entry['height'], icon_entry['data']))
                 except Exception as e:
                     self.log_status(f"Warning: Could not read icon data: {str(e)}")
                     continue

--- a/exe2iconset.py
+++ b/exe2iconset.py
@@ -260,6 +260,27 @@ class IconExtractorApp:
         
         return results
 
+    def _fix_dib_data(self, data):
+        """Fix DIB (BMP) data from RT_ICON resources for proper PIL loading."""
+        if len(data) < 4:
+            return data
+        
+        header_size = int.from_bytes(data[0:4], 'little')
+        if header_size != 40:
+            return data
+        
+        biHeight = int.from_bytes(data[8:12], 'little', signed=True)
+        if biHeight < 0:
+            return data
+        
+        biWidth = int.from_bytes(data[4:8], 'little', signed=True)
+        if biWidth <= 0:
+            return data
+        
+        fixed_data = bytearray(data)
+        struct.pack_into('<i', fixed_data, 8, biHeight // 2)
+        return bytes(fixed_data)
+
     def extract_icons_from_pe(self, file_path):
         """Extract icon groups from PE resources using pefile."""
         try:
@@ -363,7 +384,8 @@ class IconExtractorApp:
             if icon_data_list:
                 try:
                     first_icon = icon_data_list[0]
-                    img = Image.open(BytesIO(first_icon['data']))
+                    img_data = self._fix_dib_data(first_icon['data'])
+                    img = Image.open(BytesIO(img_data))
                     img = img.resize((64, 64), Image.Resampling.LANCZOS)
                     
                     photo = ImageTk.PhotoImage(img)
@@ -465,7 +487,8 @@ class IconExtractorApp:
                     src_w, src_h, src_data = best_source
                     
                     try:
-                        img = Image.open(BytesIO(src_data))
+                        img_data = self._fix_dib_data(src_data)
+                        img = Image.open(BytesIO(img_data))
                         if img.mode != 'RGBA':
                             img = img.convert('RGBA')
                         

--- a/scripts/pefile_test.py
+++ b/scripts/pefile_test.py
@@ -1,0 +1,94 @@
+import pefile
+import struct
+
+def get_entry_name(entry, level):
+    if level == 0:
+        return pefile.RESOURCE_TYPE.get(entry.id, f"TYPE_{entry.id}")
+    elif hasattr(entry, 'name') and entry.name:
+        return entry.name
+    else:
+        return f"ID_{entry.id}"
+
+def print_data_entry(pe, entry, indent):
+    if hasattr(entry, 'data') and entry.data:
+        offset = entry.data.struct.OffsetToData
+        size = entry.data.struct.Size
+        data = pe.get_memory_mapped_image()[offset:offset+size]
+        print(f"{indent}Data: offset={offset}, size={size}, bytes={len(data)}")
+        return data
+    return None
+
+def parse_group_icon(pe, data, indent):
+    if len(data) >= 6:
+        idReserved, idType, idCount = struct.unpack('<HHH', data[:6])
+        print(f"{indent}Group descriptor: type={idType}, count={idCount}")
+        offset = 6
+        for i in range(idCount):
+            if offset + 14 > len(data):
+                break
+            bWidth, bHeight, bColorCount, bReserved, wPlanes, wBitCount, dwBytesInRes, nID = struct.unpack('<BBBBHHIH', data[offset:offset+14])
+            w = bWidth if bWidth else 256
+            h = bHeight if bHeight else 256
+            print(f"{indent}  Icon entry: {w}x{h}, resource_id={nID}, size={dwBytesInRes}")
+            offset += 14
+
+def print_resource_hierarchy(pe, level=0, type_entry=None, res_name=""):
+    indent = "  " * level
+    
+    if level == 0:
+        if not hasattr(pe, 'DIRECTORY_ENTRY_RESOURCE'):
+            print("No resource directory")
+            return
+        print("=== Resource Directory Root ===")
+        for entry in pe.DIRECTORY_ENTRY_RESOURCE.entries:
+            name = get_entry_name(entry, level)
+            print(f"{indent}Type: {name} (id={entry.id})")
+            if hasattr(entry, 'directory') and entry.directory:
+                print_resource_hierarchy(pe, level + 1, entry, name)
+    
+    elif level == 1:
+        name = get_entry_name(type_entry, level)
+        print(f"{indent}Resource: {name}")
+        
+        if hasattr(type_entry, 'directory') and type_entry.directory:
+            for id_entry in type_entry.directory.entries:
+                res_id_name = get_entry_name(id_entry, level)
+                print(f"{indent}  ID/Name: {res_id_name}")
+                
+                if hasattr(id_entry, 'directory') and id_entry.directory:
+                    for lang_entry in id_entry.directory.entries:
+                        lang_id = lang_entry.id if hasattr(lang_entry, 'id') and lang_entry.id else 0
+                        primary_lang = pefile.LANG.get(lang_id & 0x3FF, f"LANG_{lang_id & 0x3FF}")
+                        print(f"{indent}    Language: {primary_lang}/0x{lang_id:04X}")
+                        
+                        data = print_data_entry(pe, lang_entry, indent + "      ")
+                        if data and 'RT_GROUP_ICON' in res_name:
+                            parse_group_icon(pe, data, indent + "      ")
+                else:
+                    data = print_data_entry(pe, id_entry, indent + "    ")
+                    if data and 'RT_GROUP_ICON' in res_name:
+                        parse_group_icon(pe, data, indent + "    ")
+
+def main():
+    import sys
+    
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <file1> [file2] ...")
+        return
+    
+    paths = sys.argv[1:]
+    
+    for path in paths:
+        print(f"\n{'='*60}")
+        print(f"File: {path}")
+        print('='*60)
+        try:
+            pe = pefile.PE(path)
+            print_resource_hierarchy(pe)
+        except Exception as e:
+            import traceback
+            print(f"Error: {e}")
+            traceback.print_exc()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

Switch from 7z extraction to direct PE resource parsing using the `pefile` library for correct icon group extraction.

## Changes

- Replace 7z-based extraction with pefile library for direct PE resource parsing
- Add recursive resource traversal to handle complex resource directory structures
- Implement correct GRPICONDIR/GRPICONDIRENTRY parsing from RT_GROUP_ICON resources
- Parse RT_ICON resources to get individual icon data referenced by group entries
- Create proper ICO files by combining group directory entries with icon data
- Add handling for DIB/BMP format icons from RT_ICON resources
- Fix upside-down DIB icons by flipping vertically
- Fix transparency for 32-bit DIB icons

## Why

The original 7z-based extraction couldn't properly parse files like shell32.dll with many icon groups. The new approach directly parses the PE resource structure to correctly identify and group icons according to the Windows ICO format specification.

## Testing

- Tested with various exe and dll files including shell32.dll
- Icons are now correctly grouped by their RT_GROUP_ICON resource entries

## Closes

Closes #3