### PR TITLE
Improve icon matching algorithm (Issue #15)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,6 +170,92 @@ gh api repos/OWNER/REPO/pulls/N -X PATCH -F body="New description text"
 gh pr merge N --squash --delete-branch
 ```
 
+### Adding Line Comments to PR
+
+Use GraphQL `addPullRequestReviewThread` mutation:
+
+```bash
+# First, get PR node ID:
+gh api graphql -f query='{repository(owner:"OWNER", name:"REPO") { pullRequest(number: N) { id } }}'
+
+# Add line comment:
+gh api graphql -f query='mutation {
+  addPullRequestReviewThread(input: {
+    pullRequestId: "PR_NODE_ID",
+    line: LINE_NUMBER,
+    side: RIGHT,
+    body: "Comment text",
+    path: "path/to/file.py"
+  }) {
+    thread { id }
+  }
+}'
+```
+
+Note: `side: RIGHT` shows the comment on the right side of the diff (added lines).
+
+### Deleting Comments
+
+```bash
+# Delete line comment (PRRC_ ID prefix):
+gh api graphql -f query='mutation {
+  deletePullRequestReviewComment(input: {id: "PRRC_ID"}) {
+    clientMutationId
+  }
+}'
+
+# Delete PR/Issue comment (IC_ ID prefix):
+gh api graphql -f query='mutation {
+  deleteIssueComment(input: {id: "IC_ID"}) {
+    clientMutationId
+  }
+}'
+```
+
+To find comment IDs, query review threads:
+```bash
+gh api graphql -f query='{repository(owner:"OWNER", name:"REPO") { 
+  pullRequest(number: N) { 
+    reviewThreads(first: 20) { 
+      nodes { id line comments(first:5) { nodes { id body } } } 
+    } 
+  } 
+ }}'
+```
+
+### Resolving/Unresolving Review Threads
+
+```bash
+# Resolve thread:
+gh api graphql -f query='mutation {
+  resolveReviewThread(input: {threadId: "THREAD_ID"}) {
+    clientMutationId
+  }
+}'
+
+# Unresolve thread:
+gh api graphql -f query='mutation {
+  unresolveReviewThread(input: {threadId: "THREAD_ID"}) {
+    clientMutationId
+  }
+}'
+```
+
+### Approving/Requesting Changes on PR
+
+```bash
+# Approve PR:
+gh pr review N --approve
+
+# Request changes:
+gh pr review N --request-changes --body "Description of changes needed"
+
+# Comment only (no approval/status):
+gh pr review N --body "Comment text"
+```
+
+Note: A user cannot approve their own PR. The PR creator must use a different account to approve.
+
 ---
 
 ## Git Commands Reference

--- a/README.md
+++ b/README.md
@@ -103,13 +103,20 @@ exe2iconset app.exe -o app.icns -v
 ## Python API
 
 ```python
-from exe2iconset import extract_icons_from_pe, create_icns_from_images
+from exe2iconset import extract_icons_from_pe, create_icns_from_images, convert_icons_to_icns_sizes, ICON_TYPE_MAP
 
 # Extract icons from PE file
 icon_groups = extract_icons_from_pe("app.exe")
 
+# Convert extracted icons to PIL images with resolutions, sutable for ICNS
+mac_icon_sizes = list(ICON_TYPE_MAP.keys())
+convert_icons_to_icns_sizes(icon_data_list, mac_icon_sizes)
+
 # Create ICNS from images
 create_icns_from_images(icon_images, "app.icns")
+
+# Also you can save images as iconset directory
+save_iconset(icon_images, "app.iconset")
 ```
 
 ## ICNS Format

--- a/exe2iconset/core/convert.py
+++ b/exe2iconset/core/convert.py
@@ -1,4 +1,5 @@
 from PIL import Image
+from bisect import bisect_left, bisect_right
 
 try:
     from .extract import extract_icons_from_pe
@@ -18,33 +19,41 @@ def convert_icons_to_icns_sizes(icon_data_list, mac_icon_sizes):
     """
     regular_icons = {}
     
-    icon_sizes = []
+    icon_selected = dict()
     for icon_entry in icon_data_list:
         try:
             img = icon_entry['image'].copy()
-            icon_sizes.append((icon_entry['width'], icon_entry['height'], img))
+            (w, h) = (icon_entry['width'], icon_entry['height'])
+            bc = icon_entry['bit_count']
+            if (w, h) in icon_selected:
+                if bc < icon_selected[(w,h)][0]:
+                    continue
+            icon_selected[(w, h)] = (bc , img)
         except Exception:
             continue
-    
-    icon_sizes.sort(key=lambda x: x[0] * x[1], reverse=True)
-    
-    for target_w, target_h in mac_icon_sizes:
-        best_source = None
-        best_diff = float('inf')
-        
-        for src_w, src_h, src_data in icon_sizes:
-            diff = abs(src_w - target_w) + abs(src_h - target_h)
-            if diff < best_diff:
-                best_diff = diff
-                best_source = (src_w, src_h, src_data)
-        
-        if best_source:
-            src_w, src_h, src_img = best_source
-            src_img = src_img.copy()
-            
+
+    target_sizes = mac_icon_sizes.copy()
+    icon_selected = dict(sorted(icon_selected.items()))
+
+    resolutions_with_exact_match = set()
+
+    for (src_w, src_h), (_, src_img) in icon_selected.items():
+        lt = bisect_left(target_sizes, (src_w, src_h))
+        rt = bisect_right(target_sizes, (src_w, src_h))
+        if lt == rt:
+            lt = lt - 1
+
+        for target_w, target_h in target_sizes[lt:rt]:            
             try:
-                resized = src_img.resize((target_w, target_h), Image.Resampling.LANCZOS)
-                regular_icons[(target_w, target_h)] = resized
+                resized = src_img
+                resize_done = False
+                if (target_w, target_h) != (src_w, src_h):
+                    resized = src_img.resize((target_w, target_h), Image.Resampling.LANCZOS)
+                    resize_done = True
+                if (target_w, target_h) not in resolutions_with_exact_match:
+                    regular_icons[(target_w, target_h)] = resized
+                if not resize_done:
+                    resolutions_with_exact_match.add((target_w, target_h))
             except Exception:
                 pass
     

--- a/exe2iconset/core/extract.py
+++ b/exe2iconset/core/extract.py
@@ -1,5 +1,4 @@
 import struct
-import io
 from io import BytesIO
 from PIL import Image
 from PIL.IcoImagePlugin import IcoFile
@@ -137,7 +136,7 @@ def extract_icons_from_pe(file_path, logger=None):
         logger: Optional callable for logging messages
         
     Returns:
-        Dict mapping group keys to list of icon dicts with 'width', 'height', 'image'
+        Dict mapping group keys to list of icon dicts with 'width', 'height', 'bit_count', 'image'
     """
     def log(msg):
         if logger:
@@ -213,11 +212,13 @@ def extract_icons_from_pe(file_path, logger=None):
                     continue
                 width = e['width'] if e['width'] != 0 else 256
                 height = e['height'] if e['height'] != 0 else 256
+                bit_count = e['bit_count']
                 img = _read_icon_image(pe, icon_data.get('offset', 0), icon_data.get('size', 0), e)
                 if img:
                     icon_list.append({
                         'width': width,
                         'height': height,
+                        'bit_count': bit_count,
                         'image': img
                     })
 
@@ -227,8 +228,9 @@ def extract_icons_from_pe(file_path, logger=None):
                 log(f"Warning: Icon group {group_id} has no valid icons")
 
         for group_key, icon_list in groups.items():
-            log(f"Debug: Group {group_key}: {len(icon_list)} icon(s)")
-
+            resolutions = ", ".join(f"{icon['width']}x{icon['height']}@{icon['bit_count']}b" for icon in icon_list)
+            log(f"Debug: Group {group_key}: {len(icon_list)} icons ({resolutions})")
+            
         return groups
 
     except Exception as e:

--- a/exe2iconset/gui.py
+++ b/exe2iconset/gui.py
@@ -251,7 +251,7 @@ class IconExtractorApp:
                     
                     if response:
                         if os.path.exists(iconset_path):
-                            shutil.rmtree(iconset_path)  
+                            shutil.rmtree(iconset_path)
                         save_iconset(regular_icons, iconset_path)
                 else:
                     self.log_status("Failed to create ICNS")

--- a/exe2iconset/gui.py
+++ b/exe2iconset/gui.py
@@ -230,49 +230,11 @@ class IconExtractorApp:
             icon_data_list = self.icon_series[self.selected_series_key]
             
             iconset_name = self.output_name.get() + ".iconset"
-            iconset_path = os.path.join(output_dir, iconset_name)
-            
-            if os.path.exists(iconset_path):
-                shutil.rmtree(iconset_path)
-            
-            os.makedirs(iconset_path)
+            iconset_path = os.path.join(output_dir, iconset_name)                      
             
             mac_icon_sizes = list(ICON_TYPE_MAP.keys())
             
-            icon_sizes = []
-            for icon_entry in icon_data_list:
-                try:
-                    img = icon_entry['image'].copy()
-                    icon_sizes.append((icon_entry['width'], icon_entry['height'], img))
-                except Exception as e:
-                    self.log_status(f"Warning: Could not read icon data: {str(e)}")
-                    continue
-            
-            icon_sizes.sort(key=lambda x: x[0] * x[1], reverse=True)
-            
-            self.log_status(f"Processing {len(icon_sizes)} icons...")
-            
-            regular_icons = {}
-            
-            for target_w, target_h in mac_icon_sizes:
-                best_source = None
-                best_diff = float('inf')
-                
-                for src_w, src_h, src_data in icon_sizes:
-                    diff = abs(src_w - target_w) + abs(src_h - target_h)
-                    if diff < best_diff:
-                        best_diff = diff
-                        best_source = (src_w, src_h, src_data)
-                
-                if best_source:
-                    src_w, src_h, src_img = best_source
-                    src_img = src_img.copy()
-                    
-                    try:
-                        resized = src_img.resize((target_w, target_h), Image.Resampling.LANCZOS)
-                        regular_icons[(target_w, target_h)] = resized
-                    except Exception as e:
-                        self.log_status(f"Error processing icon: {str(e)}")
+            regular_icons = convert_icons_to_icns_sizes(icon_data_list, mac_icon_sizes)
             
             self.log_status(f"Created {len(regular_icons)} icon sizes for ICNS.")
             
@@ -288,12 +250,11 @@ class IconExtractorApp:
                         f"Also save iconset directory for inspection?")
                     
                     if response:
-                        os.makedirs(iconset_path, exist_ok=True)
-                        for (w, h), img in regular_icons.items():
-                            img.save(os.path.join(iconset_path, f"icon_{w}x{h}.png"), 'PNG')
-                        self.log_status(f"Saved iconset in: {iconset_path}")
+                        if os.path.exists(iconset_path):
+                            shutil.rmtree(iconset_path)  
+                        save_iconset(regular_icons, iconset_path)
                 else:
-                    self.log_status(f"Failed to create ICNS")
+                    self.log_status("Failed to create ICNS")
             except Exception as e:
                 self.log_status(f"Failed to create ICNS: {str(e)}")
             

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,6 @@ def sample_icon_list(make_image):
     sizes = [(256, 256), (128, 128), (64, 64), (32, 32)]
     colors = [(255, 0, 0, 255), (0, 255, 0, 255), (0, 0, 255, 255), (255, 255, 0, 255)]
     return [
-        {'width': w, 'height': h, 'image': make_image((w, h), c)}
+        {'width': w, 'height': h, 'bit_count': 32, 'image': make_image((w, h), c)}
         for (w, h), c in zip(sizes, colors)
     ]

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -28,7 +28,11 @@ def test_convert_icons_empty_list():
 
 def test_convert_icons_all_sizes(sample_image):
     """Test conversion to all ICNS sizes."""
-    icon_data = [{'width': 512, 'height': 512, 'image': sample_image}]
+    sample_icon_size = 512
+    icon_data = [{'width': sample_icon_size, 
+                  'height': sample_icon_size,
+                  'bit_count': 32,
+                  'image': sample_image}]
     mac_icon_sizes = list(ICON_TYPE_MAP.keys())
     
     result = convert_icons_to_icns_sizes(icon_data, mac_icon_sizes)
@@ -52,6 +56,7 @@ def test_save_iconset(sample_icon_list, tmp_path):
 def test_save_iconset_empty(tmp_path):
     """Test saving empty iconset."""
     result = save_iconset({}, str(tmp_path / "empty"))
+    assert result is True
     assert os.path.exists(tmp_path / "empty")
 
 


### PR DESCRIPTION
- Add bit_count to extracted icons for quality selection
- Deduplicate icons by resolution, keep highest bit_count
- Use bisect for efficient target range lookup
- Prioritize exact matches over resized variants
- Fall back to closest smaller target when no exact matches
- Skip resized when exact match exists (macOS auto-scales)
- Show resolution with bit depth in debug output
- Refactor GUI to use core function
- Update tests and fixtures to include bit_count

Closes #15