### PR TITLE
Improve UI design for large icon sets (Issue #4)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -272,6 +272,16 @@ Use `git commit --amend` ONLY when:
 - Were created by someone else
 - Are part of a published history
 
+**Commit Fix Options:**
+
+When you need to commit a small fix, ask human for one of these options:
+
+1. **Amend** - Add fix to the most recent commit (only if not pushed)
+2. **New commit** - Create separate commit, then wait for push approval  
+3. **Wait** - Don't commit yet, wait for human review first
+
+Use the `question` tool to ask for confirmation before proceeding.
+
 **Commands:**
 **IMPORTANT: Never push without explicit human approval. AI agent must wait for human to say "approved" or "go ahead" before executing any push command.**
 

--- a/README.md
+++ b/README.md
@@ -50,10 +50,17 @@ run_gui()
 #### GUI Workflow
 
 1. **Select EXE File**: Click "Browse..." to select a Windows executable (EXE, DLL, MUN)
-2. **Extract Icons**: Click "Extract Icons" to extract icon groups from the PE file
-3. **Select Series**: Choose an icon series from the list in Step 2
+2. **Extract Icons**: Click "Extract Icons" to extract icon groups from the PE file. A progress bar shows extraction progress for files with 300+ icons.
+3. **Select Series**: Choose an icon series from the Treeview list. Thumbnails load lazily - only visible items are rendered for performance.
 4. **Create ICNS**: Enter output name and click "Create ICNS"
 5. **Save Location**: ICNS file will be saved in the selected output directory
+
+The icon list shows compact details like `ID:101, LANG:1033, all:64²×32bit` where:
+- **ID**: Resource ID (e.g., 101)
+- **LANG**: Language code (e.g., 1033 = English)
+- **all**: All sizes in the group (e.g., 64²×32bit means 64x64 at 32-bit color)
+
+Click the status bar to view the full activity log in a popup window.
 
 ### CLI
 

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ run_gui()
 
 #### GUI Workflow
 
-1. **Select EXE File**: Click "Browse..." to select a Windows executable (EXE, DLL, MUN)
-2. **Extract Icons**: Click "Extract Icons" to extract icon groups from the PE file. A progress bar shows extraction progress for files with 300+ icons.
-3. **Select Series**: Choose an icon series from the Treeview list. Thumbnails load lazily - only visible items are rendered for performance.
+1. **Select EXE File**: Click "Browse..." or enter path and press Enter
+2. **Extract Icons**: Extraction starts automatically after file selection. A progress bar shows extraction progress.
+3. **Select Series**: Choose an icon series from the Treeview list
 4. **Create ICNS**: Enter output name and click "Create ICNS"
 5. **Save Location**: ICNS file will be saved in the selected output directory
 
@@ -76,28 +76,12 @@ exe2iconset <file.exe> -g icongroup_47_1033 -o output.icns
 
 # Create ICNS with iconset directory for inspection
 exe2iconset <file.exe> -o output.icns --iconset
+
+# Verbose output for debugging
+exe2iconset <file.exe> -v
 ```
 
-#### CLI Examples
-
-```bash
-# List all icon groups in a file
-exe2iconset app.exe --list
-
-# Extract icons using the first available group
-exe2iconset app.exe -o app.icns
-
-# Extract from a specific group (shown in --list output)
-exe2iconset app.exe -g icongroup_3_1033 -o myapp.icns
-
-# Create iconset directory for manual inspection
-exe2iconset app.exe -o app.icns --iconset
-
-# Verbose output
-exe2iconset app.exe -o app.icns -v
-```
-
-#### CLI Options
+### CLI Options
 
 | Option | Description |
 |--------|-------------|

--- a/exe2iconset/core/convert.py
+++ b/exe2iconset/core/convert.py
@@ -43,7 +43,7 @@ def convert_icons_to_icns_sizes(icon_data_list, mac_icon_sizes):
         if lt == rt:
             lt = lt - 1
 
-        for target_w, target_h in target_sizes[lt:rt]:            
+        for target_w, target_h in target_sizes[lt:rt]:
             try:
                 resized = src_img
                 resize_done = False

--- a/exe2iconset/core/extract.py
+++ b/exe2iconset/core/extract.py
@@ -128,12 +128,13 @@ def _read_via_icoimageplugin(raw_data, icon_entry):
         return None
 
 
-def extract_icons_from_pe(file_path, logger=None):
+def extract_icons_from_pe(file_path, logger=None, progress_callback=None):
     """Extract icon groups from PE resources using pefile.
     
     Args:
         file_path: Path to PE file (exe, dll, mun)
         logger: Optional callable for logging messages
+        progress_callback: Optional callable(current, total) for progress updates
         
     Returns:
         Dict mapping group keys to list of icon dicts with 'width', 'height', 'bit_count', 'image'
@@ -141,6 +142,10 @@ def extract_icons_from_pe(file_path, logger=None):
     def log(msg):
         if logger:
             logger(msg)
+    
+    def progress(current, total):
+        if progress_callback:
+            progress_callback(current, total)
     
     try:
         if pefile is None:
@@ -175,7 +180,10 @@ def extract_icons_from_pe(file_path, logger=None):
         log(f"Debug: Found {len(rt_group_resources)} RT_GROUP_ICON entries")
         
         group_icon_entries = [(res['id'], res['lang'], res['offset'], res['size']) for res in rt_group_resources]
-
+        
+        total_groups = len(group_icon_entries)
+        processed = 0
+        
         for group_id, group_lang, data_offset, size in group_icon_entries:
             data = pe.get_memory_mapped_image()[data_offset:data_offset+size]
             if len(data) < 6:
@@ -226,7 +234,12 @@ def extract_icons_from_pe(file_path, logger=None):
                 groups[group_key] = icon_list
             else:
                 log(f"Warning: Icon group {group_id} has no valid icons")
+            
+            processed += 1
+            progress(processed, total_groups)
 
+        progress(total_groups, total_groups)
+        
         for group_key, icon_list in groups.items():
             resolutions = ", ".join(f"{icon['width']}x{icon['height']}@{icon['bit_count']}b" for icon in icon_list)
             log(f"Debug: Group {group_key}: {len(icon_list)} icons ({resolutions})")

--- a/exe2iconset/gui.py
+++ b/exe2iconset/gui.py
@@ -92,13 +92,11 @@ class IconExtractorApp:
         tree_frame.columnconfigure(0, weight=1)
         tree_frame.rowconfigure(0, weight=1)
         
-        self.icon_tree = ttk.Treeview(tree_frame, columns=("name", "count", "action"), show="headings", selectmode="browse")
+        self.icon_tree = ttk.Treeview(tree_frame, columns=("name", "count"), show="headings", selectmode="browse")
         self.icon_tree.heading("name", text="Series Name")
         self.icon_tree.heading("count", text="Icons")
-        self.icon_tree.heading("action", text="")
-        self.icon_tree.column("name", width=300)
+        self.icon_tree.column("name", width=350)
         self.icon_tree.column("count", width=60)
-        self.icon_tree.column("action", width=80)
         
         vsb = ttk.Scrollbar(tree_frame, orient="vertical", command=self.icon_tree.yview)
         self.icon_tree.configure(yscrollcommand=vsb.set)
@@ -106,9 +104,10 @@ class IconExtractorApp:
         self.icon_tree.grid(row=0, column=0, sticky=(tk.W, tk.E, tk.N, tk.S))
         vsb.grid(row=0, column=1, sticky=(tk.N, tk.S))
         
-        self.icon_tree.bind("<Button-1>", self._on_tree_click)
-        
         self.icon_tree.bind("<<TreeviewSelect>>", self._on_tree_select)
+        
+        self.convert_btn = ttk.Button(step3_frame, text="Convert to ICNS", command=self.on_convert_click)
+        self.convert_btn.grid(row=2, column=0, pady=(10, 0), sticky=(tk.W, tk.E))
         
         status_frame = ttk.LabelFrame(main_frame, text="Status", padding="10")
         status_frame.grid(row=4, column=0, columnspan=3, sticky=(tk.W, tk.E), pady=(0, 10))
@@ -225,11 +224,18 @@ class IconExtractorApp:
         
         for series_name, icon_data_list in self.icon_series.items():
             count = len(icon_data_list)
-            self.icon_tree.insert("", "end", values=(series_name, count, "Convert"))
+            self.icon_tree.insert("", "end", values=(series_name, count))
         
         self.progress["maximum"] = total
         self.progress["value"] = total
-        self.log_status(f"Found {len(self.icon_series)} icon series. Click 'Convert' to create ICNS.")
+        
+        if total == 1:
+            first_item = self.icon_tree.get_children()[0]
+            self.icon_tree.selection_set(first_item)
+            self.selected_series_key = self.icon_tree.item(first_item, "values")[0]
+            self.log_status(f"Found 1 icon series. Click 'Convert' to create ICNS.")
+        else:
+            self.log_status(f"Found {len(self.icon_series)} icon series. Select one and click 'Convert'.")
     
     def _on_tree_select(self, event):
         selection = self.icon_tree.selection()
@@ -238,21 +244,17 @@ class IconExtractorApp:
             series_name = self.icon_tree.item(item, "values")[0]
             self.select_series(series_name)
     
-    def _on_tree_click(self, event):
-        region = self.icon_tree.identify_region(event.x, event.y)
-        if region == "cell":
-            column = self.icon_tree.identify_column(event.x)
-            item = self.icon_tree.identify_row(event.y)
-            if item and column == "#3":
-                series_name = self.icon_tree.item(item, "values")[0]
-                self.select_and_convert(series_name)
-    
     def select_series(self, series_name):
         self.selected_series_key = series_name
-    
-    def select_and_convert(self, series_name):
-        self.select_series(series_name)
         self.log_status(f"Selected series: {series_name} with {len(self.icon_series[series_name])} icons")
+    
+    def on_convert_click(self):
+        if self.selected_series_key is None:
+            if len(self.icon_series) == 1:
+                self.selected_series_key = list(self.icon_series.keys())[0]
+            else:
+                messagebox.showwarning("Select Series", "Please select an icon series from the list.")
+                return
         self.create_icns()
     
     def create_icns(self):

--- a/exe2iconset/gui.py
+++ b/exe2iconset/gui.py
@@ -24,6 +24,7 @@ class IconExtractorApp:
         self.selected_series_key = None
         self.thumbnail_images = []
         self.thumbnail_cache = {}
+        self.log_messages = []
         
         self.create_widgets()
         self.check_requirements()
@@ -36,12 +37,8 @@ class IconExtractorApp:
         self.root.rowconfigure(0, weight=1)
         main_frame.columnconfigure(1, weight=1)
         
-        title_label = ttk.Label(main_frame, text="EXE to ICNS Converter", 
-                                font=("Arial", 16, "bold"))
-        title_label.grid(row=0, column=0, columnspan=3, pady=(0, 20))
-        
         step1_frame = ttk.LabelFrame(main_frame, text="Step 1: Select Windows Executable", padding="10")
-        step1_frame.grid(row=1, column=0, columnspan=3, sticky=(tk.W, tk.E), pady=(0, 10))
+        step1_frame.grid(row=0, column=0, columnspan=3, sticky=(tk.W, tk.E), pady=(0, 10))
         step1_frame.columnconfigure(1, weight=1)
         
         ttk.Label(step1_frame, text="EXE File:").grid(row=0, column=0, sticky=tk.W, padx=(0, 5))
@@ -114,13 +111,16 @@ class IconExtractorApp:
         self.convert_btn = ttk.Button(step3_frame, text="Convert to ICNS", command=self.on_convert_click)
         self.convert_btn.grid(row=2, column=0, pady=(10, 0), sticky=(tk.W, tk.E))
         
-        status_frame = ttk.LabelFrame(main_frame, text="Status", padding="10")
-        status_frame.grid(row=4, column=0, columnspan=3, sticky=(tk.W, tk.E), pady=(0, 10))
+        self.log_messages = []
+        
+        status_frame = ttk.Frame(main_frame)
+        status_frame.grid(row=4, column=0, columnspan=3, sticky=(tk.W, tk.E), pady=(0, 5))
         status_frame.columnconfigure(0, weight=1)
         
-        self.status_text = tk.Text(status_frame, height=6, width=80, state=tk.DISABLED, 
-                                   relief=tk.FLAT)
-        self.status_text.grid(row=0, column=0, sticky=(tk.W, tk.E))
+        self.status_label = ttk.Label(status_frame, text="Ready", relief=tk.SUNKEN, 
+                                      anchor=tk.W, padding=(5, 2))
+        self.status_label.grid(row=0, column=0, sticky=(tk.W, tk.E))
+        self.status_label.bind("<Button-1>", self._show_log_popup)
         
         main_frame.rowconfigure(3, weight=1)
     
@@ -428,12 +428,36 @@ class IconExtractorApp:
     
     def log_status(self, message):
         def update_status():
-            self.status_text.config(state=tk.NORMAL)
-            self.status_text.insert(tk.END, message + "\n")
-            self.status_text.see(tk.END)
-            self.status_text.config(state=tk.DISABLED)
+            self.log_messages.append(message)
+            self.status_label.config(text=message)
         
         self.root.after(0, update_status)
+    
+    def _show_log_popup(self, event):
+        if not self.log_messages:
+            return
+        
+        popup = tk.Toplevel(self.root)
+        popup.title("Log")
+        popup.geometry("600x400")
+        
+        text_frame = tk.Frame(popup)
+        text_frame.pack(fill=tk.BOTH, expand=True)
+        
+        text = tk.Text(text_frame, wrap=tk.WORD)
+        text.grid(row=0, column=0, sticky=(tk.W, tk.E, tk.N, tk.S))
+        
+        vsb = tk.Scrollbar(text_frame, orient=tk.VERTICAL, command=text.yview)
+        vsb.grid(row=0, column=1, sticky=(tk.N, tk.S))
+        text.configure(yscrollcommand=vsb.set)
+        
+        text_frame.columnconfigure(0, weight=1)
+        text_frame.rowconfigure(0, weight=1)
+        
+        for msg in self.log_messages:
+            text.insert(tk.END, msg + "\n")
+        
+        text.config(state=tk.DISABLED)
 
 
 def run_gui():

--- a/exe2iconset/gui.py
+++ b/exe2iconset/gui.py
@@ -1,8 +1,5 @@
 import os
-import shutil
 import struct
-import subprocess
-import sys
 import threading
 import tkinter as tk
 from tkinter import ttk, filedialog, messagebox
@@ -21,6 +18,7 @@ class IconExtractorApp:
         self.root.geometry("900x700")
         
         self.exe_path = tk.StringVar()
+        self.output_dir = tk.StringVar()
         self.selected_icons = []
         self.icon_series = {}
         self.selected_series_key = None
@@ -48,17 +46,45 @@ class IconExtractorApp:
         
         exe_entry = ttk.Entry(step1_frame, textvariable=self.exe_path, width=50)
         exe_entry.grid(row=0, column=1, sticky=(tk.W, tk.E), padx=(0, 5))
+        exe_entry.bind('<Return>', lambda e: self.extract_icons())
         
         ttk.Button(step1_frame, text="Browse...", command=self.browse_exe).grid(row=0, column=2)
-        ttk.Button(step1_frame, text="Extract Icons", command=self.extract_icons).grid(row=0, column=3, padx=(10, 0))
         
-        step2_frame = ttk.LabelFrame(main_frame, text="Step 2: Select Icon Series", padding="10")
-        step2_frame.grid(row=2, column=0, columnspan=3, sticky=(tk.W, tk.E, tk.N, tk.S), pady=(0, 10))
+        self.output_name = tk.StringVar(value="appicon")
+        self.save_icns = tk.BooleanVar(value=True)
+        self.save_iconset = tk.BooleanVar(value=False)
         
-        step2_frame.columnconfigure(0, weight=1)
-        step2_frame.rowconfigure(0, weight=1)
+        step2_frame = ttk.LabelFrame(main_frame, text="Step 2: Select Output Path", padding="10")
+        step2_frame.grid(row=2, column=0, columnspan=3, sticky=(tk.W, tk.E), pady=(0, 10))
+        step2_frame.columnconfigure(1, weight=1)
         
-        icon_canvas_frame = ttk.Frame(step2_frame)
+        ttk.Label(step2_frame, text="Output Folder:").grid(row=0, column=0, sticky=tk.W, padx=(0, 5))
+        
+        output_dir_entry = ttk.Entry(step2_frame, textvariable=self.output_dir, width=50)
+        output_dir_entry.grid(row=0, column=1, sticky=(tk.W, tk.E), padx=(0, 5))
+        self.output_dir.trace_add('write', lambda *args: self.update_output_preview())
+        
+        ttk.Button(step2_frame, text="Browse...", command=self.browse_output_dir).grid(row=0, column=2)
+        
+        ttk.Label(step2_frame, text="Name:").grid(row=1, column=0, sticky=tk.W, padx=(0, 5))
+        
+        output_name_entry = ttk.Entry(step2_frame, textvariable=self.output_name, width=30)
+        output_name_entry.grid(row=1, column=1, sticky=tk.W, padx=(0, 20))
+        self.output_name.trace_add('write', lambda *args: self.update_output_preview())
+        
+        ttk.Checkbutton(step2_frame, text=".icns", variable=self.save_icns, command=self.update_output_preview).grid(row=1, column=2, padx=(10, 0))
+        ttk.Checkbutton(step2_frame, text=".iconset directory", variable=self.save_iconset, command=self.update_output_preview).grid(row=1, column=3)
+        
+        self.output_preview = ttk.Label(step2_frame, text="", font=("Arial", 9), foreground="#666")
+        self.output_preview.grid(row=2, column=0, columnspan=4, pady=(5, 0))
+        
+        step3_frame = ttk.LabelFrame(main_frame, text="Step 3: Select and Convert", padding="10")
+        step3_frame.grid(row=3, column=0, columnspan=3, sticky=(tk.W, tk.E, tk.N, tk.S), pady=(0, 10))
+        
+        step3_frame.columnconfigure(0, weight=1)
+        step3_frame.rowconfigure(0, weight=1)
+        
+        icon_canvas_frame = ttk.Frame(step3_frame)
         icon_canvas_frame.grid(row=0, column=0, sticky=(tk.W, tk.E, tk.N, tk.S))
         icon_canvas_frame.columnconfigure(0, weight=1)
         icon_canvas_frame.rowconfigure(0, weight=1)
@@ -81,17 +107,6 @@ class IconExtractorApp:
         self.icon_container.bind("<Configure>", configure_canvas)
         canvas.bind("<Configure>", lambda e: canvas.itemconfig(self.icon_window, width=e.width))
         
-        step3_frame = ttk.LabelFrame(main_frame, text="Step 3: Convert to macOS ICNS", padding="10")
-        step3_frame.grid(row=3, column=0, columnspan=3, sticky=(tk.W, tk.E), pady=(0, 10))
-        
-        ttk.Label(step3_frame, text="Output Name:").grid(row=0, column=0, sticky=tk.W, padx=(0, 5))
-        
-        self.output_name = tk.StringVar(value="appicon")
-        output_entry = ttk.Entry(step3_frame, textvariable=self.output_name, width=30)
-        output_entry.grid(row=0, column=1, sticky=tk.W, padx=(0, 20))
-        
-        ttk.Button(step3_frame, text="Create ICNS Package", command=self.create_icns).grid(row=0, column=2)
-        
         status_frame = ttk.LabelFrame(main_frame, text="Status", padding="10")
         status_frame.grid(row=4, column=0, columnspan=3, sticky=(tk.W, tk.E), pady=(0, 10))
         status_frame.columnconfigure(0, weight=1)
@@ -100,7 +115,7 @@ class IconExtractorApp:
                                    relief=tk.FLAT)
         self.status_text.grid(row=0, column=0, sticky=(tk.W, tk.E))
         
-        main_frame.rowconfigure(2, weight=1)
+        main_frame.rowconfigure(3, weight=1)
     
     def check_requirements(self):
         missing_tools = []
@@ -126,7 +141,35 @@ class IconExtractorApp:
         )
         if filename:
             self.exe_path.set(filename)
+            
+            exe_dir = os.path.dirname(filename)
+            exe_stem = os.path.splitext(os.path.basename(filename))[0]
+            self.output_dir.set(exe_dir)
+            self.output_name.set(exe_stem)
+            self.update_output_preview()
+            
             self.log_status(f"Selected file: {filename}")
+            self.extract_icons()
+    
+    def browse_output_dir(self):
+        dirname = filedialog.askdirectory(title="Select Output Directory")
+        if dirname:
+            self.output_dir.set(dirname)
+            self.update_output_preview()
+    
+    def update_output_preview(self, *args):
+        output_dir = self.output_dir.get()
+        output_name = self.output_name.get()
+        parts = []
+        if self.save_icns.get():
+            parts.append(output_name + ".icns")
+        if self.save_iconset.get():
+            parts.append(output_name + ".iconset")
+        if not parts:
+            self.output_preview.config(text="Select .icns and/or .iconset to save output")
+        elif output_dir:
+            preview_text = "Output: " + ", ".join(parts) + " in " + output_dir
+            self.output_preview.config(text=preview_text)
     
     def extract_icons(self):
         if not self.exe_path.get():
@@ -188,16 +231,16 @@ class IconExtractorApp:
             info_label = ttk.Label(series_frame, text=f"{len(icon_data_list)} icons")
             info_label.grid(row=1, column=0, padx=5, pady=(0, 5))
             
-            select_btn = ttk.Button(series_frame, text="Select Series", 
-                                    command=lambda sn=series_name: self.select_series(sn))
-            select_btn.grid(row=2, column=0, padx=5, pady=(0, 5))
+            convert_btn = ttk.Button(series_frame, text="Convert", 
+                                    command=lambda sn=series_name: self.select_and_convert(sn))
+            convert_btn.grid(row=2, column=0, padx=5, pady=(0, 5))
             
             col += 1
             if col >= max_cols:
                 col = 0
                 row += 1
         
-        self.log_status(f"Found {len(self.icon_series)} icon series. Select one to convert.")
+        self.log_status(f"Found {len(self.icon_series)} icon series. Click 'Convert' to create ICNS.")
     
     def select_series(self, series_name):
         self.selected_series_key = series_name
@@ -210,26 +253,33 @@ class IconExtractorApp:
                 else:
                     child.configure(relief=tk.RAISED)
     
+    def select_and_convert(self, series_name):
+        self.select_series(series_name)
+        self.create_icns()
+    
     def create_icns(self):
         if (self.selected_series_key is None) or not self.icon_series.get(self.selected_series_key):
             messagebox.showerror("Error", "Please select an icon series first")
             return
         
-        output_dir = filedialog.askdirectory(title="Select Output Directory")
-        if not output_dir:
-            return
+        if not self.output_dir.get():
+            self.browse_output_dir()
+            if not self.output_dir.get():
+                return
         
-        thread = threading.Thread(target=self._create_icns_thread, args=(output_dir,))
+        thread = threading.Thread(target=self._create_icns_thread)
         thread.daemon = True
         thread.start()
     
-    def _create_icns_thread(self, output_dir):
+    def _create_icns_thread(self):
+        output_dir = self.output_dir.get()
         self.log_status("Starting ICNS conversion...")
         
         try:
             icon_data_list = self.icon_series[self.selected_series_key]
+            output_name = self.output_name.get()
             
-            iconset_name = self.output_name.get() + ".iconset"
+            iconset_name = output_name + ".iconset"
             iconset_path = os.path.join(output_dir, iconset_name)                      
             
             mac_icon_sizes = list(ICON_TYPE_MAP.keys())
@@ -238,32 +288,28 @@ class IconExtractorApp:
             
             self.log_status(f"Created {len(regular_icons)} icon sizes for ICNS.")
             
-            icns_path = os.path.join(output_dir, self.output_name.get() + ".icns")
+            icns_path = os.path.join(output_dir, output_name + ".icns")
             
+            saved = []
             try:
-                if create_icns_from_images(regular_icons, icns_path):
-                    self.log_status(f"Successfully created ICNS file: {icns_path}")
-                    
-                    response = messagebox.askyesno("Success", 
-                        f"ICNS file created successfully!\n\n"
-                        f"Location: {icns_path}\n\n"
-                        f"Also save iconset directory for inspection?")
-                    
-                    if response:
-                        if os.path.exists(iconset_path):
-                            shutil.rmtree(iconset_path)
-                        save_iconset(regular_icons, iconset_path)
-                else:
-                    self.log_status("Failed to create ICNS")
+                if self.save_icns.get():
+                    if create_icns_from_images(regular_icons, icns_path):
+                        saved.append(icns_path)
+                        self.log_status(f"Successfully created ICNS file: {icns_path}")
+                    else:
+                        self.log_status("Failed to create ICNS")
+                if self.save_iconset.get():
+                    if not os.path.exists(iconset_path):
+                        os.makedirs(iconset_path)
+                    save_iconset(regular_icons, iconset_path)
+                    saved.append(iconset_path)
+                    self.log_status(f"Successfully created iconset: {iconset_path}")
             except Exception as e:
-                self.log_status(f"Failed to create ICNS: {str(e)}")
+                self.log_status(f"Failed to create output: {str(e)}")
             
-            if sys.platform == 'win32':
-                os.startfile(output_dir)
-            elif sys.platform == 'darwin':
-                subprocess.run(['open', output_dir])
-            elif sys.platform == 'linux':
-                subprocess.run(['xdg-open', output_dir])
+            if saved:
+                self.root.after(0, lambda: messagebox.showinfo("Success", 
+                    f"Created:\n" + "\n".join(saved)))
                 
         except Exception as e:
             self.log_status(f"Error creating ICNS: {str(e)}")

--- a/exe2iconset/gui.py
+++ b/exe2iconset/gui.py
@@ -82,30 +82,33 @@ class IconExtractorApp:
         step3_frame.grid(row=3, column=0, columnspan=3, sticky=(tk.W, tk.E, tk.N, tk.S), pady=(0, 10))
         
         step3_frame.columnconfigure(0, weight=1)
-        step3_frame.rowconfigure(0, weight=1)
+        step3_frame.rowconfigure(1, weight=1)
         
-        icon_canvas_frame = ttk.Frame(step3_frame)
-        icon_canvas_frame.grid(row=0, column=0, sticky=(tk.W, tk.E, tk.N, tk.S))
-        icon_canvas_frame.columnconfigure(0, weight=1)
-        icon_canvas_frame.rowconfigure(0, weight=1)
+        self.progress = ttk.Progressbar(step3_frame, mode='determinate')
+        self.progress.grid(row=0, column=0, sticky=(tk.W, tk.E), pady=(0, 5))
         
-        canvas = tk.Canvas(icon_canvas_frame, highlightthickness=1, highlightbackground='#ccc')
-        canvas.grid(row=0, column=0, sticky=(tk.W, tk.E, tk.N, tk.S))
+        tree_frame = ttk.Frame(step3_frame)
+        tree_frame.grid(row=1, column=0, sticky=(tk.W, tk.E, tk.N, tk.S))
+        tree_frame.columnconfigure(0, weight=1)
+        tree_frame.rowconfigure(0, weight=1)
         
-        scrollbar = ttk.Scrollbar(icon_canvas_frame, orient="vertical", command=canvas.yview)
-        scrollbar.grid(row=0, column=1, sticky=(tk.N, tk.S))
+        self.icon_tree = ttk.Treeview(tree_frame, columns=("name", "count", "action"), show="headings", selectmode="browse")
+        self.icon_tree.heading("name", text="Series Name")
+        self.icon_tree.heading("count", text="Icons")
+        self.icon_tree.heading("action", text="")
+        self.icon_tree.column("name", width=300)
+        self.icon_tree.column("count", width=60)
+        self.icon_tree.column("action", width=80)
         
-        canvas.configure(yscrollcommand=scrollbar.set)
+        vsb = ttk.Scrollbar(tree_frame, orient="vertical", command=self.icon_tree.yview)
+        self.icon_tree.configure(yscrollcommand=vsb.set)
         
-        self.icon_container = ttk.Frame(canvas)
-        self.icon_window = canvas.create_window((0, 0), window=self.icon_container, anchor=tk.NW)
+        self.icon_tree.grid(row=0, column=0, sticky=(tk.W, tk.E, tk.N, tk.S))
+        vsb.grid(row=0, column=1, sticky=(tk.N, tk.S))
         
-        def configure_canvas(event):
-            canvas.configure(scrollregion=canvas.bbox("all"))
-            canvas.itemconfig(self.icon_window, width=canvas.winfo_width())
+        self.icon_tree.bind("<Button-1>", self._on_tree_click)
         
-        self.icon_container.bind("<Configure>", configure_canvas)
-        canvas.bind("<Configure>", lambda e: canvas.itemconfig(self.icon_window, width=e.width))
+        self.icon_tree.bind("<<TreeviewSelect>>", self._on_tree_select)
         
         status_frame = ttk.LabelFrame(main_frame, text="Status", padding="10")
         status_frame.grid(row=4, column=0, columnspan=3, sticky=(tk.W, tk.E), pady=(0, 10))
@@ -176,8 +179,12 @@ class IconExtractorApp:
             messagebox.showerror("Error", "Please select an EXE file first")
             return
         
-        for widget in self.icon_container.winfo_children():
-            widget.destroy()
+        for item in self.icon_tree.get_children():
+            self.icon_tree.delete(item)
+        
+        self.visible_items = []
+        self.loaded_count = 0
+        self.progress["value"] = 0
         
         self.selected_icons = []
         self.icon_series = {}
@@ -189,16 +196,20 @@ class IconExtractorApp:
     def _extract_icons_thread(self):
         self.log_status("Extracting icons from PE resources...")
         
+        def progress_callback(current, total):
+            self.root.after(0, lambda c=current, t=total: self.progress.config(value=c * 100 // t))
+        
         try:
-            icon_files = extract_icons_from_pe(self.exe_path.get(), self.log_status)
+            icon_files = extract_icons_from_pe(self.exe_path.get(), self.log_status, progress_callback)
             if not icon_files:
                 self.log_status("No icons found in the PE resources.")
+                self.root.after(0, lambda: self.progress.config(value=0))
                 return
 
             self.icon_series = icon_files
             self.log_status(f"Extracted {len(self.icon_series)} icon groups from PE resources.")
 
-            self.root.after(0, self.display_icons)
+            self.display_icons()
             return
 
         except Exception as e:
@@ -206,55 +217,42 @@ class IconExtractorApp:
             return
     
     def display_icons(self):
-        row, col = 0, 0
-        max_cols = 5
+        self.visible_items = list(self.icon_series.keys())
+        total = len(self.visible_items)
+        
+        for item in self.icon_tree.get_children():
+            self.icon_tree.delete(item)
         
         for series_name, icon_data_list in self.icon_series.items():
-            series_frame = ttk.LabelFrame(self.icon_container, text=series_name, padding="5")
-            series_frame.grid(row=row, column=col, padx=5, pady=5, sticky=(tk.W, tk.E, tk.N, tk.S))
-            
-            if icon_data_list:
-                try:
-                    first_icon = icon_data_list[0]
-                    img = first_icon['image'].resize((64, 64), Image.Resampling.LANCZOS)
-                    
-                    photo = ImageTk.PhotoImage(img)
-                    
-                    icon_label = ttk.Label(series_frame, image=photo)
-                    icon_label.image = photo
-                    icon_label.grid(row=0, column=0, padx=5, pady=5)
-                    
-                except Exception as e:
-                    error_label = ttk.Label(series_frame, text=f"Error: {str(e)[:20]}")
-                    error_label.grid(row=0, column=0, padx=5, pady=5)
-            
-            info_label = ttk.Label(series_frame, text=f"{len(icon_data_list)} icons")
-            info_label.grid(row=1, column=0, padx=5, pady=(0, 5))
-            
-            convert_btn = ttk.Button(series_frame, text="Convert", 
-                                    command=lambda sn=series_name: self.select_and_convert(sn))
-            convert_btn.grid(row=2, column=0, padx=5, pady=(0, 5))
-            
-            col += 1
-            if col >= max_cols:
-                col = 0
-                row += 1
+            count = len(icon_data_list)
+            self.icon_tree.insert("", "end", values=(series_name, count, "Convert"))
         
+        self.progress["maximum"] = total
+        self.progress["value"] = total
         self.log_status(f"Found {len(self.icon_series)} icon series. Click 'Convert' to create ICNS.")
+    
+    def _on_tree_select(self, event):
+        selection = self.icon_tree.selection()
+        if selection:
+            item = selection[0]
+            series_name = self.icon_tree.item(item, "values")[0]
+            self.select_series(series_name)
+    
+    def _on_tree_click(self, event):
+        region = self.icon_tree.identify_region(event.x, event.y)
+        if region == "cell":
+            column = self.icon_tree.identify_column(event.x)
+            item = self.icon_tree.identify_row(event.y)
+            if item and column == "#3":
+                series_name = self.icon_tree.item(item, "values")[0]
+                self.select_and_convert(series_name)
     
     def select_series(self, series_name):
         self.selected_series_key = series_name
-        self.log_status(f"Selected series: {series_name} with {len(self.icon_series[series_name])} icons")
-        
-        for child in self.icon_container.winfo_children():
-            if isinstance(child, ttk.LabelFrame):
-                if child.cget('text') == series_name:
-                    child.configure(relief=tk.SUNKEN)
-                else:
-                    child.configure(relief=tk.RAISED)
     
     def select_and_convert(self, series_name):
         self.select_series(series_name)
+        self.log_status(f"Selected series: {series_name} with {len(self.icon_series[series_name])} icons")
         self.create_icns()
     
     def create_icns(self):
@@ -266,6 +264,8 @@ class IconExtractorApp:
             self.browse_output_dir()
             if not self.output_dir.get():
                 return
+        
+        self.icon_tree.config(selectmode="none")
         
         thread = threading.Thread(target=self._create_icns_thread)
         thread.daemon = True
@@ -283,22 +283,27 @@ class IconExtractorApp:
             iconset_path = os.path.join(output_dir, iconset_name)                      
             
             mac_icon_sizes = list(ICON_TYPE_MAP.keys())
+            total_sizes = len(mac_icon_sizes)
+            
+            self.log_status(f"Converting {len(icon_data_list)} icons to {total_sizes} sizes...")
             
             regular_icons = convert_icons_to_icns_sizes(icon_data_list, mac_icon_sizes)
             
-            self.log_status(f"Created {len(regular_icons)} icon sizes for ICNS.")
+            self.log_status(f"Created {len(regular_icons)} icon sizes.")
             
             icns_path = os.path.join(output_dir, output_name + ".icns")
             
             saved = []
             try:
                 if self.save_icns.get():
+                    self.log_status("Creating ICNS file...")
                     if create_icns_from_images(regular_icons, icns_path):
                         saved.append(icns_path)
                         self.log_status(f"Successfully created ICNS file: {icns_path}")
                     else:
                         self.log_status("Failed to create ICNS")
                 if self.save_iconset.get():
+                    self.log_status("Creating iconset directory...")
                     if not os.path.exists(iconset_path):
                         os.makedirs(iconset_path)
                     save_iconset(regular_icons, iconset_path)
@@ -313,6 +318,8 @@ class IconExtractorApp:
                 
         except Exception as e:
             self.log_status(f"Error creating ICNS: {str(e)}")
+        finally:
+            self.root.after(0, lambda: self.icon_tree.config(selectmode="browse"))
     
     def log_status(self, message):
         def update_status():

--- a/exe2iconset/gui.py
+++ b/exe2iconset/gui.py
@@ -22,6 +22,8 @@ class IconExtractorApp:
         self.selected_icons = []
         self.icon_series = {}
         self.selected_series_key = None
+        self.thumbnail_images = []
+        self.thumbnail_cache = {}
         
         self.create_widgets()
         self.check_requirements()
@@ -92,13 +94,16 @@ class IconExtractorApp:
         tree_frame.columnconfigure(0, weight=1)
         tree_frame.rowconfigure(0, weight=1)
         
-        self.icon_tree = ttk.Treeview(tree_frame, columns=("name", "count"), show="headings", selectmode="browse")
-        self.icon_tree.heading("name", text="Series Name")
-        self.icon_tree.heading("count", text="Icons")
-        self.icon_tree.column("name", width=350)
-        self.icon_tree.column("count", width=60)
+        self.icon_tree = ttk.Treeview(tree_frame, columns=("details",), selectmode="browse")
+        style = ttk.Style(self.root)
+        style.configure("Treeview", rowheight=130)
         
-        vsb = ttk.Scrollbar(tree_frame, orient="vertical", command=self.icon_tree.yview)
+        self.icon_tree.heading("#0", text="Icons Preview")
+        self.icon_tree.heading("details", text="Details")
+        self.icon_tree.column("#0", width=300, minwidth=300)
+        self.icon_tree.column("details", width=200, minwidth=200)
+        
+        vsb = ttk.Scrollbar(tree_frame, orient="vertical", command=self._on_tree_scroll)
         self.icon_tree.configure(yscrollcommand=vsb.set)
         
         self.icon_tree.grid(row=0, column=0, sticky=(tk.W, tk.E, tk.N, tk.S))
@@ -118,6 +123,10 @@ class IconExtractorApp:
         self.status_text.grid(row=0, column=0, sticky=(tk.W, tk.E))
         
         main_frame.rowconfigure(3, weight=1)
+    
+    def _on_tree_scroll(self, *args):
+        self.icon_tree.yview(*args)
+        self.root.after(50, self._prepare_visible_thumbnails)
     
     def check_requirements(self):
         missing_tools = []
@@ -222,17 +231,69 @@ class IconExtractorApp:
         for item in self.icon_tree.get_children():
             self.icon_tree.delete(item)
         
+        self.thumbnail_cache = {}
+        self.thumbnail_images = []
+        
         for series_name, icon_data_list in self.icon_series.items():
             count = len(icon_data_list)
-            self.icon_tree.insert("", "end", values=(series_name, count))
+            
+            if icon_data_list:
+                parts = series_name.split('_')
+                id_part = parts[1] if len(parts) > 1 else "?"
+                lang_part = parts[2] if len(parts) > 2 else "?"
+                
+                sorted_icons = sorted(icon_data_list, key=lambda x: x.get('width', 0) * x.get('height', 0), reverse=True)
+                
+                # Group icons by resolution
+                by_res = {}
+                for icon in sorted_icons:
+                    w = icon.get('width', 0)
+                    h = icon.get('height', 0)
+                    cb = icon.get('bit_count', 0)
+                    if w and h and cb:
+                        key = f"{w}x{h}"
+                        if key not in by_res:
+                            by_res[key] = set()
+                        by_res[key].add(cb)
+                
+                res_parts = []
+                for res_key in by_res:
+                    bits = sorted(by_res[res_key], reverse=True)
+                    res = res_key.split('x')
+                    w = res[0]
+                    h = res[1]
+                    superscript = '²'
+                    if h == w:
+                        res_str = f"{w}{superscript}"
+                    else:
+                        res_str = f"{w}×{h}"
+                    if len(bits) == 1:
+                        res_parts.append(f"{res_str}×{bits[0]}bit")
+                    else:
+                        bits_str = ','.join(str(b) for b in bits)
+                        res_parts.append(f"{res_str}×{{{bits_str}}}bit")
+                
+                details = f"ID:{id_part}, LANG:{lang_part}, all:{', '.join(res_parts)}"
+                
+                self.thumbnail_cache[series_name] = icon_data_list
+                self.icon_tree.insert("", "end", iid=series_name, values=(details,))
+            else:
+                self.icon_tree.insert("", "end", iid=series_name, values=("No icons",))
+        
+        self.progress["maximum"] = total
+        self.progress["value"] = total
+        
+        self.icon_tree.bind("<Configure>", lambda e: self._prepare_visible_thumbnails())
+        self.root.after(100, self._prepare_visible_thumbnails)
         
         self.progress["maximum"] = total
         self.progress["value"] = total
         
         if total == 1:
+            first_key = list(self.icon_series.keys())[0]
             first_item = self.icon_tree.get_children()[0]
             self.icon_tree.selection_set(first_item)
-            self.selected_series_key = self.icon_tree.item(first_item, "values")[0]
+            self.selected_series_key = first_key
             self.log_status(f"Found 1 icon series. Click 'Convert' to create ICNS.")
         else:
             self.log_status(f"Found {len(self.icon_series)} icon series. Select one and click 'Convert'.")
@@ -240,9 +301,9 @@ class IconExtractorApp:
     def _on_tree_select(self, event):
         selection = self.icon_tree.selection()
         if selection:
-            item = selection[0]
-            series_name = self.icon_tree.item(item, "values")[0]
-            self.select_series(series_name)
+            item_id = selection[0]
+            self.select_series(item_id)
+            self._prepare_visible_thumbnails()
     
     def select_series(self, series_name):
         self.selected_series_key = series_name
@@ -272,6 +333,48 @@ class IconExtractorApp:
         thread = threading.Thread(target=self._create_icns_thread)
         thread.daemon = True
         thread.start()
+    
+    def _prepare_visible_thumbnails(self):
+        all_items = list(self.thumbnail_cache.keys())
+        
+        target_height = 130
+        
+        for item_id in all_items:
+            if self.icon_tree.item(item_id, "image"):
+                continue
+            
+            bbox = self.icon_tree.bbox(item_id)
+            if not bbox:
+                continue
+            
+            icon_data_list = self.thumbnail_cache[item_id]
+            
+            sorted_icons = sorted(icon_data_list, key=lambda x: x.get('width', 0) * x.get('height', 0), reverse=True)
+            
+            thumbnails = []
+            for icon in sorted_icons:
+                try:
+                    w, h = icon.get('width', 32), icon.get('height', 32)
+                    img = icon['image'].copy()
+                    if h > target_height:
+                        scale = target_height / h
+                        new_w, new_h = int(w * scale), target_height
+                        img = img.resize((new_w, new_h), Image.Resampling.LANCZOS)
+                    thumbnails.append(img)
+                except:
+                    pass
+            
+            if thumbnails:
+                total_width = sum(t.width for t in thumbnails)
+                composite = Image.new('RGBA', (total_width, target_height), (0, 0, 0, 0))
+                x_offset = 0
+                for thumb in thumbnails:
+                    composite.paste(thumb, (x_offset, 0))
+                    x_offset += thumb.width
+                
+                photo = ImageTk.PhotoImage(composite)
+                self.thumbnail_images.append(photo)
+                self.icon_tree.item(item_id, image=photo)
     
     def _create_icns_thread(self):
         output_dir = self.output_dir.get()


### PR DESCRIPTION
## Summary
- Replace frame-based grid with ttk.Treeview for better performance with large icon sets
- Add progress bar for extraction phase (335+ icons)
- Implement lazy thumbnail loading using bbox to detect visible items
- Create composite images showing all icons side-by-side (no 8-icon limit)
- Add compact details format: ID:101, LANG:1033, all:64²×32bit
- Compact status bar with click-to-expand popup log

Closes #4