### PR TITLE
Integrate setuptools-scm for automatic version sync from git tags

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Git tag (e.g., v0.2.0)'
+        description: 'Git tag (e.g., v0.x.x)'
         required: false
         type: string
   push:

--- a/.gitignore
+++ b/.gitignore
@@ -206,5 +206,8 @@ marimo/_static/
 marimo/_lsp/
 __marimo__/
 
+# setuptools-scm generated version file
+exe2iconset/_version.py
+
 # ai vibe coding logs
 sessions/

--- a/BUILD.md
+++ b/BUILD.md
@@ -23,7 +23,7 @@ The `.app` bundle is automatically built when you publish a GitHub release:
 
 1. Go to the Releases page
 2. Click "Draft a new release"
-3. Enter version tag (e.g., `v0.2.0`)
+3. Enter version tag (e.g., `v0.x.x`)
 4. Add release notes
 5. Click "Publish release"
 

--- a/exe2iconset.spec
+++ b/exe2iconset.spec
@@ -8,6 +8,13 @@ import platform
 import sys
 from pathlib import Path
 
+# Read version from installed package at build time
+try:
+    from importlib.metadata import version as _get_version
+    _app_version = _get_version("exe2iconset")
+except Exception:
+    _app_version = "0.0.0"
+
 block_cipher = None
 _root = Path(SPECPATH)
 
@@ -95,8 +102,8 @@ if _target == 'macos':
         info_plist={
             'CFBundleName': 'Exe2Iconset',
             'CFBundleDisplayName': 'Exe2Iconset',
-            'CFBundleVersion': '0.2.0',
-            'CFBundleShortVersionString': '0.2.0',
+            'CFBundleVersion': _app_version,
+            'CFBundleShortVersionString': _app_version,
             'CFBundlePackageType': 'APPL',
             'CFBundleExecutable': _binary_name,
             'LSMinimumSystemVersion': '10.13',

--- a/exe2iconset/__init__.py
+++ b/exe2iconset/__init__.py
@@ -1,4 +1,12 @@
-__version__ = "0.2.0"
+try:
+    from importlib.metadata import version
+
+    __version__ = version("exe2iconset")
+except Exception:
+    try:
+        from ._version import version as __version__
+    except ImportError:
+        __version__ = "0.0.0"
 
 from .core.extract import (
     extract_icons_from_pe,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
+requires = ["setuptools>=61.0", "wheel", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "exe2iconset"
-version = "0.2.0"
+dynamic = ["version"]
 description = "Extract icons from Windows EXE/DLL files and create macOS ICNS files"
 readme = "README.md"
 license = {text = "MIT"}
@@ -48,6 +48,10 @@ exe2iconset-gui = "exe2iconset.gui:run_gui"
 [project.urls]
 Homepage = "https://github.com/anakham/Exe2Iconset"
 Repository = "https://github.com/anakham/Exe2Iconset"
+
+[tool.setuptools_scm]
+write_to = "exe2iconset/_version.py"
+fallback_version = "0.0.0"
 
 [tool.setuptools.packages.find]
 where = ["."]


### PR DESCRIPTION
## Summary

- Integrate setuptools-scm to automatically derive package version from git tags
- Package `__version__`, `CFBundleVersion`, and `CFBundleShortVersionString` now sync automatically
- When a tag like `v0.3.0` is pushed, all version references resolve to `0.3.0`

## Changes

| File | Change |
|---|---|
| `pyproject.toml` | Add setuptools-scm, use `dynamic = ["version"]` |
| `exe2iconset/__init__.py` | Dynamic `__version__` via `importlib.metadata` |
| `exe2iconset.spec` | Read version at build time for Info.plist |
| `.gitignore` | Ignore generated `_version.py` |
| `BUILD.md`, `build-release.yml` | Remove hardcoded `v0.2.0` references |

## Testing

```bash
PYTHONPATH=. pytest tests/  # 16 passed
```

```bash
python -c "from exe2iconset import __version__; print(__version__)"
# 0.2.2.dev1+gafffa9e74.d20260525 (dev version, no tag yet)
# After tag: prints the tag version (e.g. 0.3.0)
```

## Usage

Releases are triggered automatically by pushing a `v*` tag:

```bash
git tag v0.3.0 main
git push origin v0.3.0
```

Closes #44